### PR TITLE
Update mypy follow-imports to silent

### DIFF
--- a/lib/pronto/mypy.rb
+++ b/lib/pronto/mypy.rb
@@ -37,7 +37,7 @@ module Pronto
 
       return [] if file_args.empty?
 
-      stdout, stderr, = Open3.capture3("#{pylint_executable} #{file_args}")
+      stdout, stderr, = Open3.capture3("#{mypy_executable} #{file_args}")
       stderr.strip!
 
       puts "WARN: pronto-mypy:\n\n#{stderr}" unless stderr.empty?
@@ -56,8 +56,8 @@ module Pronto
 
     private
 
-    def pylint_executable
-      'mypy'
+    def mypy_executable
+      'mypy --follow-imports=silent'
     end
 
     def python_patches

--- a/lib/pronto/mypy/version.rb
+++ b/lib/pronto/mypy/version.rb
@@ -2,6 +2,6 @@
 
 module Pronto
   module MypyVersion
-    VERSION = '0.1.1'
+    VERSION = '0.1.2'
   end
 end


### PR DESCRIPTION
This step was hanging on this step https://github.com/GetResQ/pronto-mypy/blob/c5de0b7169f15e7c55f91e621335318518e6b5c0/lib/pronto/mypy.rb#L50 while running pronto, so removing the number of error messages should resolve the issue.